### PR TITLE
Fixed the variable name in terraform.tfvars_sample

### DIFF
--- a/Neo4j-Causal-Cluster-with-Bloom/terraform.tfvars_sample
+++ b/Neo4j-Causal-Cluster-with-Bloom/terraform.tfvars_sample
@@ -13,7 +13,7 @@ service_account = "<Service-Account>"
 #--------------------------------------------------------------
 
 vpc_name = "vpc-neo4j-custom"
-vpc_subnetwork = "subnetwork-neo4j-custom"
+subnetwork_name = "subnetwork-neo4j-custom"
 
 
 #--------------------------------------------------------------


### PR DESCRIPTION
Changed from vpc_subnetwork to subnetwork_name to match the name used in variables.tf