### PR TITLE
Update setup.sh

### DIFF
--- a/Neo4j-GDS-with-Bloom/scripts/setup.sh
+++ b/Neo4j-GDS-with-Bloom/scripts/setup.sh
@@ -43,7 +43,7 @@ if [ ! -f $file ]; then
     sudo rm -f bloom-plugin-3*
     sudo rm -f neo4j-bloom-*
     sudo rm -f readme.txt
-    sudo unzip installation-staging/plugins/neo4j-graph-data-science-${gds_version}-standalone.zip
+    sudo unzip installation-staging/plugins/neo4j-graph-data-science-${gds_version}.zip
     sudo mv neo4j-graph-data-science-${gds_version}.jar plugins
     sudo mv installation-staging/plugins/apoc-${apoc_version}-all.jar plugins
     sudo mv installation-staging/plugins/google-cloud-storage-dependencies-${gcs_version}-apoc.jar plugins


### PR DESCRIPTION
the latest version of GDS zip file does not have -standalone in its name. 
removed to be neo4j-graph-data-science-${gds_version}.zip

e.g.
> unzip neo4j-graph-data-science-2.1.8.zip
Archive:  neo4j-graph-data-science-2.1.8.zip
  inflating: neo4j-graph-data-science-2.1.8.jar